### PR TITLE
Fix the plugin not working on windows

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -21,7 +21,7 @@ export const onCreateWebpackConfig = ({ stage, plugins, rules, actions }, option
         })
         .use.map(loader => {
             if (!isProduction) {
-                ['/css-loader/locals', '/css-loader/'].forEach(modulePath => {
+                ['/css-loader/locals', '/css-loader/', '\\css-loader\\locals', '\\css-loader\\'].forEach(modulePath => {
                     if (loader.loader.includes(modulePath)) {
                         loader.loader = require.resolve('typings-for-css-modules-loader');
                     }


### PR DESCRIPTION
Just a simple change, maybe you want to do that with `path.sep` instead, but this should be fine.